### PR TITLE
Even further simplified

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "es6-proxy-polyfill": "2.0.1",
     "immer": "6.0.2",
     "proxy-polyfill": "0.3.1",
-    "pullstate": "1.11.2",
+    "pullstate": "1.13.0",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "regenerator-runtime": "0.13.5"

--- a/src/RemoteHello2.tsx
+++ b/src/RemoteHello2.tsx
@@ -1,15 +1,8 @@
-import {createAsyncAction, errorResult, successResult} from "pullstate";
+import { createAsyncActionDirect } from "pullstate";
 import React from 'react';
 import fetchRemoteMessage from './fetchRemoteMessage';
 
-const asyncFetch = createAsyncAction<string>(async (from) => {
-  try {
-    const result = await fetchRemoteMessage(from);
-    return successResult(result);
-  } catch (error) {
-    return errorResult(undefined, error.message);
-  }
-});
+const asyncFetch = createAsyncActionDirect(fetchRemoteMessage);
 
 export default function RemoteHello2() {
   const remoteFetch = asyncFetch.use('RemoteHello2', { initiate: false });
@@ -19,8 +12,8 @@ export default function RemoteHello2() {
   }
 
   return <div>
-    <button onClick={() => asyncFetch.run("RemoteHello2")}>Fetch remote message</button>
+    <button onClick={() => remoteFetch.execute()}>Fetch remote message</button>
     {remoteFetch.isFinished && remoteFetch.error && (<div className='error'>Error: {remoteFetch.message}</div>)}
-    {remoteFetch.renderPayload(payload => <div className='success'>Hello, {payload}</div>)}
+    {remoteFetch.renderPayload((payload) => <div className='success'>Hello, {payload}</div>)}
   </div>
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,8 @@ module.exports = {
     filename: 'bundle.js'
   },
   resolve: {
-    extensions: ['.ts', '.tsx', '.js']
+    extensions: ['.ts', '.tsx', '.js'],
+    symlinks: false
   },
   module: {
     rules: [{


### PR DESCRIPTION
Just some extra changes that simplify things even further with an `execute()` method, and much simpler way to define an async action by simply passing in the Promise.